### PR TITLE
activesupport version change

### DIFF
--- a/smart_rspec.gemspec
+++ b/smart_rspec.gemspec
@@ -18,11 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.1'
+  spec.add_runtime_dependency 'activesupport', '~> 5.0'
   spec.add_runtime_dependency 'rspec-collection_matchers', '~> 1.1', '>= 1.1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'faker', '~> 1.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
+  spec.add_development_dependency 'pry', '~> 0.10.3'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/smart_rspec.gemspec
+++ b/smart_rspec.gemspec
@@ -18,13 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 5.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.1'
   spec.add_runtime_dependency 'rspec-collection_matchers', '~> 1.1', '>= 1.1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'faker', '~> 1.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'pry', '~> 0.10.3'
-  spec.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
- Changed version of activesupport so that smart rspec can be used with programs that have Rails 5.0 dependency. 
